### PR TITLE
feat: user document write trigger for lowercase field maintenance

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -9,3 +9,4 @@
 
 // Export all functions
 export { helloWorld } from "./utils";
+export { onUserWritten } from "./users";

--- a/functions/src/users/index.ts
+++ b/functions/src/users/index.ts
@@ -1,0 +1,28 @@
+import { onDocumentWritten } from "firebase-functions/v2/firestore";
+
+// Trigger to maintain lowercase fields
+export const onUserWritten = onDocumentWritten(
+  "users/{userId}",
+  async (event) => {
+    if (!event.data) return;
+    const afterData = event.data.after?.data();
+    if (!afterData) return;
+
+    const { displayName, username } = afterData;
+    if (!displayName || !username) return;
+
+    // Only update if the lowercase fields don't match
+    if (
+      afterData.displayNameLower !== displayName.toLowerCase() ||
+      afterData.usernameLower !== username.toLowerCase()
+    ) {
+      await event.data.after.ref.set(
+        {
+          displayNameLower: displayName.toLowerCase(),
+          usernameLower: username.toLowerCase(),
+        },
+        { merge: true }
+      );
+    }
+  }
+);


### PR DESCRIPTION
### TL;DR
Added a Firebase function to maintain lowercase versions of user display names and usernames.

This is to enable case-insensitive search. There's not really any other good way to do it: https://stackoverflow.com/questions/66364761/is-there-a-way-to-search-in-firebase-firestore-without-saving-another-field-in-l

### What changed?
Created a new Firebase function `onUserWritten` that triggers when user documents are modified. The function automatically creates and updates `displayNameLower` and `usernameLower` fields by converting the original fields to lowercase.

### How to test?
1. Create or update a user document in the `users` collection
2. Set or modify the `displayName` or `username` fields
3. Verify that `displayNameLower` and `usernameLower` fields are automatically created/updated with lowercase versions
4. Confirm that the function only triggers when the lowercase values don't match the original fields

### Why make this change?
To enable case-insensitive queries and comparisons for user display names and usernames without requiring client-side lowercase conversion or maintaining lowercase versions manually.